### PR TITLE
Createing a new page for listing all pages of all spaces

### DIFF
--- a/crawl.py
+++ b/crawl.py
@@ -569,6 +569,7 @@ def generate_all_space_pages(do_pages, html_dir='html', skip_largest=0, skip_sma
                 tdr(status_totals[status])
             writer.write("</tr>")
         writer.write(html="</table>")
+        writer.write(html=f"<script>{JAVASCRIPT}</script>")
     if do_pages:
         with open_for_writing(f"{html_dir}/all_spaces_pages.html") as fout:
             writer = HtmlOutlineWriter(fout, style=SPACES_STYLE, title="All spaces pages") 
@@ -586,7 +587,14 @@ def generate_all_space_pages(do_pages, html_dir='html', skip_largest=0, skip_sma
 
 #A simple JS code to add sorting functionility to a HTML table:
 #Ref: https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript
-JAVASCRIPT= """const getCellValue = (tr, idx) => tr.children[idx].innerText || tr.children[idx].textContent;
+#getCellValue have been changed from the link above to relfect the dynamic type of table in space
+JAVASCRIPT= """
+
+const getCellValue = (tr, idx) => {
+        if(tr.children[idx] === undefined) return false;
+        return tr.children[idx].innerText || tr.children[idx].textContent
+};
+
 
 const comparer = (idx, asc) => (a, b) => ((v1, v2) => 
     v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2)

--- a/crawl.py
+++ b/crawl.py
@@ -539,12 +539,12 @@ def generate_all_space_pages(do_pages, html_dir='html'):
     if do_pages:
         with open_for_writing(f"{html_dir}/all_spaces_pages.html") as fout:
             writer = HtmlOutlineWriter(fout, style=SPACES_STYLE, title="All spaces pages") 
-            writer.write(html="<table><tr><th>Space </th> <th> Created at </th> <th> Last Edited </th> </tr>")
+            writer.write(html="<table><tr><th>Space </th> <th> Created </th> <th> Last Edited </th> <th> Last Edited by: </th>  </tr>")
             for space in spaces:
                 for page in space.all_pages:
-                    writer.write(html=f"<tr> <td class='right'>{space.name} </td> <td class='right'>{page.created.when} </td> <td class='right'>{page.lastedit.when} </td>  </tr>")
+                    writer.write(html=f"<tr> <td class='right'>{space.name}_page </td> <td class='right'>{page.created.when} </td> <td class='right'>{page.lastedit.when} </td>  </td> <td class='right'>{page.lastedit.who} </td> </tr>")
                 for page in space.blog_posts:
-                    writer.write(html=f"<tr> <td class='right'>{space.name} </td> <td class='right'>{page.created.when} </td> <td class='right'>{page.lastedit.when} </td>  </tr>")
+                    writer.write(html=f"<tr> <td class='right'>{space.name}_blog </td> <td class='right'>{page.created.when} </td> <td class='right'>{page.lastedit.when} </td>  </td> <td class='right'>{page.lastedit.who} </td> </tr>")
             writer.write(html="</table>")
             writer.write(html=f"<script>{JAVASCRIPT}</script>")
 

--- a/crawl.py
+++ b/crawl.py
@@ -536,10 +536,37 @@ def generate_all_space_pages(do_pages, html_dir='html'):
                 writer.write(html=f"<td class='right'>{status_totals[status]}")
             writer.write("</tr>")
         writer.write(html="</table>")
+    if do_pages:
+        with open_for_writing(f"{html_dir}/all_spaces_pages.html") as fout:
+            writer = HtmlOutlineWriter(fout, style=SPACES_STYLE, title="All spaces pages") 
+            writer.write(html="<table><tr><th>Space </th> <th> Created at </th> <th> Last Edited </th> </tr>")
+            for space in spaces:
+                for page in space.all_pages:
+                    writer.write(html=f"<tr> <td class='right'>{space.name} </td> <td class='right'>{page.created.when} </td> <td class='right'>{page.lastedit.when} </td>  </tr>")
+                for page in space.blog_posts:
+                    writer.write(html=f"<tr> <td class='right'>{space.name} </td> <td class='right'>{page.created.when} </td> <td class='right'>{page.lastedit.when} </td>  </tr>")
+            writer.write(html="</table>")
+            writer.write(html=f"<script>{JAVASCRIPT}</script>")
 
     with open("space_sizes.json", "w") as f:
         json.dump(space_sizes, f)
 
+#A simple JS code to add sorting functionility to a HTML table:
+#Ref: https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript
+JAVASCRIPT= """const getCellValue = (tr, idx) => tr.children[idx].innerText || tr.children[idx].textContent;
+
+const comparer = (idx, asc) => (a, b) => ((v1, v2) => 
+    v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2)
+    )(getCellValue(asc ? a : b, idx), getCellValue(asc ? b : a, idx));
+
+// do the work...
+document.querySelectorAll('th').forEach(th => th.addEventListener('click', (() => {
+    const table = th.closest('table');
+    Array.from(table.querySelectorAll('tr:nth-child(n+2)'))
+        .sort(comparer(Array.from(th.parentNode.children).indexOf(th), this.asc = !this.asc))
+        .forEach(tr => table.appendChild(tr) );
+})));
+"""
 PERM_SHORTHANDS = {
     (False, False): "Internal",
     (False, True): "Logged-in",


### PR DESCRIPTION
Create a new HTML page, which includes a table which the following column name:

- Space name
- Created at 
- Updated at 

All the pages are sorted by clicking on their header name, the JS code to support that functionality was imported from [here](https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript). 

Need to do:

- [ ]  Handle errors, e.g. when a page edit/update doesn't exist
- [ ]  Add more properties of a page, e.g. likes, labels...etc
- [ ]  Enhance the UI/UX of the table, may use [this](https://datatables.net/)?
- [ ] Any other request[s] per @nedbat review? 
